### PR TITLE
Bump Kotlin to 1.9.10

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -69,6 +69,11 @@ android {
         release {
            signingConfig signingConfigs.release
         }
+
+        debug {
+            signingConfig signingConfigs.debug
+            minifyEnabled true
+        }
     }
 
     buildFeatures {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
After your last dependency upgrade project build was failing since minimum kotlin version for package info plus is 1.8.10.

In this PR I:

- Bumped Kotlin to 1.9.10 (Latest)
- Fixed build errors