### PR TITLE
Fix: TabBar Changes delayed (1s) when scrolling

### DIFF
--- a/lib/app/modules/home.dart
+++ b/lib/app/modules/home.dart
@@ -42,6 +42,13 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
       length: pages.length,
       vsync: this,
     );
+    _tabController.animation
+      ..addListener(() {
+        setState(() {
+          value = _tabController.animation.value.round();
+          if (value != _currentIndex) setState(() => _currentIndex = value); //_tabController.animation.value returns double
+        });
+      });
     tabController.addListener(() {
       setState(() {
         tabIndex = tabController.index;
@@ -201,7 +208,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             ),
           ),
           bottomNavigationBar: NavigationBar(
-            onDestinationSelected: (int index) => changeTabIndex(index),
+            onDestinationSelected: (int index) => changeTabIndex(index), // maybe here also something different
             selectedIndex: tabIndex,
             destinations: [
               NavigationDestination(

--- a/lib/app/modules/home.dart
+++ b/lib/app/modules/home.dart
@@ -42,13 +42,12 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
       length: pages.length,
       vsync: this,
     );
-    _tabController.animation
-      ..addListener(() {
-        setState(() {
-          value = _tabController.animation.value.round();
-          if (value != _currentIndex) setState(() => _currentIndex = value); //_tabController.animation.value returns double
-        });
+    tabController.animation?.addListener(() {
+      setState(() {
+        int value = (tabController.animation!.value).round();
+        if (value != tabIndex) setState(() => tabIndex = value);
       });
+    });
     tabController.addListener(() {
       setState(() {
         tabIndex = tabController.index;
@@ -208,7 +207,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             ),
           ),
           bottomNavigationBar: NavigationBar(
-            onDestinationSelected: (int index) => changeTabIndex(index), // maybe here also something different
+            onDestinationSelected: (int index) => changeTabIndex(index),
             selectedIndex: tabIndex,
             destinations: [
               NavigationDestination(


### PR DESCRIPTION
Hello @Leonavichus ,

I love this app and would like to help improving it.

One thing that triggers me every time: When I scroll between the three tabs (WeatherPage, ListWeatherCard, SettingsPage) it takes ages for the TabBar to show the selected tabIndex.

I found this StackOverflow question: https://stackoverflow.com/questions/57948157/tabcontroller-does-not-change-when-scrolling-the-screenlike-its-waiting-1-sec. I think this is the way we can solve this issue...

I have implemented the basics but not tested it, because I don't have SDKs and everything set up. There are probably many other things which need to be changed in order for this to work...

Nevertheless, it would be a great honor for me if you test these changes and we maybe see them in the next release...

Looking forward for your reply 😊